### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/beam/RunPipeline.java
+++ b/src/main/java/io/kestra/plugin/beam/RunPipeline.java
@@ -337,7 +337,7 @@ public class RunPipeline extends AbstractExecScript implements io.kestra.core.mo
         if (!reqs.isEmpty()) {
             Path target = Paths.get("/tmp/beam-py-" + UUID.randomUUID());
             prelude = "mkdir -p " + shellQuote(target.toString())
-                + " && python3 -m pip install --no-cache-dir --target " + shellQuote(target.toString()) + " " + String.join(" ", reqs)
+                + " && python3 -m pip install --no-cache-dir --target " + shellQuote(target.toString()) + " " + reqs.stream().map(this::shellQuote).collect(java.util.stream.Collectors.joining(" "))
                 + " && ";
             env.put("PYTHONPATH", target.toString());
         } else {
@@ -435,8 +435,8 @@ public class RunPipeline extends AbstractExecScript implements io.kestra.core.mo
         Map<String, String> options,
         Map<String, Object> runnerOptions) {
         List<String> args = new ArrayList<>();
-        options.forEach((k, v) -> args.add("--" + k + "=" + v));
-        runnerOptions.forEach((k, v) -> args.add("--" + k + "=" + stringify(v)));
+        options.forEach((k, v) -> args.add("--" + k + "=" + shellQuote(v)));
+        runnerOptions.forEach((k, v) -> args.add("--" + k + "=" + shellQuote(stringify(v))));
         return args;
     }
 

--- a/src/main/java/io/kestra/plugin/beam/config/DataflowRunnerConfig.java
+++ b/src/main/java/io/kestra/plugin/beam/config/DataflowRunnerConfig.java
@@ -42,6 +42,7 @@ public class DataflowRunnerConfig implements RunnerConfig {
 
     @Schema(title = "Path to a service account key file used for authentication")
     @PluginProperty(group = "connection", secret = true)
+    @ToString.Exclude
     private String serviceAccountKey;
 
     @Schema(title = "Whether the job should update an existing pipeline with the same name")


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** Shell injection via unquoted pip requirements (`src/main/java/io/kestra/plugin/beam/RunPipeline.java:339`)
  - Fix: Wrap each element of `reqs` with `shellQuote()` using a stream before joining, preventing shell metacharacter injection through requirement strings.

- **HIGH** Shell injection via unquoted pipeline options in buildOptionArgs (`src/main/java/io/kestra/plugin/beam/RunPipeline.java:437`)
  - Fix: Apply `shellQuote()` to each option value in `buildOptionArgs` for both `options` and `runnerOptions` maps before adding to the args list.

- **MEDIUM** GCP service account key exposed via Lombok @ToString (`src/main/java/io/kestra/plugin/beam/config/DataflowRunnerConfig.java:45`)
  - Fix: Added `@ToString.Exclude` annotation to `serviceAccountKey` field so Lombok's generated `toString()` omits the sensitive credential from log output.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-beam/issues/67
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
